### PR TITLE
added ability to get volume by host (volumes connected to host) via Get-PfaVolume

### DIFF
--- a/PureStoragePowerShell.psm1
+++ b/PureStoragePowerShell.psm1
@@ -1,4 +1,4 @@
-﻿<#	
+<#	
 	===========================================================================
 	 Created with: 	SAPIEN Technologies, Inc., PowerShell Studio 2015
 	 Created by:   	barkz@PureStoragePowerShell.com
@@ -1167,16 +1167,21 @@ function Get-PfaHistoricalVolumePerformance()
 #.ExternalHelp PureStoragePowerShell.psm1-help.xml
 function Get-PfaVolume()
 {
-	[CmdletBinding()]
+	[CmdletBinding(DefaultParameterSetName="ByName")]
 	Param (
 		[Parameter(Mandatory = $False)][ValidateNotNullOrEmpty()][string] $FlashArray,
-		[Parameter(Mandatory = $True)][ValidateNotNullOrEmpty()][string] $Name,
+		[Parameter(ParameterSetName="ByName",Mandatory = $True)][ValidateNotNullOrEmpty()][string] $Name,
+		[Parameter(ParameterSetName="ByHost",ValueFromPipelineByPropertyName=$true)][ValidateNotNullOrEmpty()][string]$HostName,
 		[Parameter(Mandatory = $True)][ValidateNotNullOrEmpty()][Microsoft.PowerShell.Commands.WebRequestSession]$Session
 	)
 	
 	try
 	{
-		$Uri = "$PureStorageURIBase/volume/$Name"
+		$Uri = Switch ($PsCmdlet.ParameterSetName) {
+			## for getting the volumes associated with the given host
+			"ByHost" {"$PureStorageURIBase/host/$HostName/volume"}
+			"ByName" {"$PureStorageURIBase/volume/$Name"}
+		}
 		return (Invoke-RestMethod -Method GET -Uri $Uri -WebSession $Session -ContentType "application/json" -TimeoutSec 900)
 	}
 	catch


### PR DESCRIPTION
Can now use `Get-PfaVolume` to get the volumes that are connected to a particular host. This is in addition to the "by name" functionality that was in place in `Get-PfaVolume`.  Helpful for when one wants to find out what are the volumes connected to a host.  Now allows this in one call.

Previously, the route for getting volumes connected to a host was to get all volumes and get their private- and shared connections (so, two calls for every volume defined on the array).

To provide this, I added a new parameter, `HostName`, and a couple of ParameterSets to function `Get-PfaVolume`.

Did not update help, as the help is external, nor did I update the installer MSI (I assume that the latter would happen at release time).

Happy to discuss this update, and anything else about this useful module.